### PR TITLE
로그인, 회원가입 API에 ADMIN, CEO, USER 권한 생성 및 권한 설정

### DIFF
--- a/Back/build.gradle
+++ b/Back/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     //id 'org.asciidoctor.convert' version '1.5.9.2' // Asciidoctor 플러그인 적용
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
-    //id("org.asciidoctor.jvm.pdf") version "3.2.0"
+    //id 'org.asciidoctor.jvm.pdf' version "3.2.0"
     //id 'org.asciidoctor.jvm.gems' version "3.2.0"
     id 'java'
 }
@@ -64,15 +64,15 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs') //기존에 존재하는 docs를 삭제
 }
 
-task copyDocument(type: Copy) {
-    dependsOn asciidoctor
-
-    from file("build/asciidoc/html5/")
-    into file("src/main/resources/static/docs")
-}
-build {
-    dependsOn copyDocument
-}
+//task copyDocument(type: Copy) {
+//    dependsOn asciidoctor
+//
+//    from file("build/asciidoc/html5/")
+//    into file("src/main/resources/static/docs")
+//}
+//build {
+//    dependsOn copyDocument
+//}
 
 bootJar {
     dependsOn asciidoctor //jar 생성전에 asciidoctor 테스크가 실행되도록 설정, gradle build 시 asciidoctor → bootJar 순으로 수행

--- a/Back/build.gradle
+++ b/Back/build.gradle
@@ -1,7 +1,10 @@
 plugins {
     id 'org.springframework.boot' version '2.5.5'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'org.asciidoctor.convert' version '1.5.9.2' // Asciidoctor 플러그인 적용
+    //id 'org.asciidoctor.convert' version '1.5.9.2' // Asciidoctor 플러그인 적용
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    //id("org.asciidoctor.jvm.pdf") version "3.2.0"
+    //id 'org.asciidoctor.jvm.gems' version "3.2.0"
     id 'java'
 }
 
@@ -34,7 +37,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation "javax.xml.bind:jaxb-api"
     // 프로젝트에서 .adoc파일들을 읽어 build/generated-snippets 에 파일읽어 HTML문서로 export
-    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    //asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     // Maven 과 같이 test Scope 에 대한 mockMvc 의존성을 추가 (WebClient, Assured 사용가능)
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     // 언어 요청에 맞게 다국어 처리 위한 i18n 세팅. yml에서 다국화 하기 위해
@@ -59,6 +62,16 @@ asciidoctor { //asciidoctor task 설정
 
 asciidoctor.doFirst {
     delete file('src/main/resources/static/docs') //기존에 존재하는 docs를 삭제
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+
+    from file("build/asciidoc/html5/")
+    into file("src/main/resources/static/docs")
+}
+build {
+    dependsOn copyDocument
 }
 
 bootJar {

--- a/Back/build.gradle
+++ b/Back/build.gradle
@@ -64,20 +64,20 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs') //기존에 존재하는 docs를 삭제
 }
 
-//task copyDocument(type: Copy) {
-//    dependsOn asciidoctor
-//
-//    from file("build/asciidoc/html5/")
-//    into file("src/main/resources/static/docs")
-//}
-//build {
-//    dependsOn copyDocument
-//}
-
 bootJar {
     dependsOn asciidoctor //jar 생성전에 asciidoctor 테스크가 실행되도록 설정, gradle build 시 asciidoctor → bootJar 순으로 수행
     // jar static 폴더에 rest docs가 HTML로 생성되면 넣어준다., gradle build 시 ./build/asciidoc/html5/ 에 html 파일 생성
     from ("${asciidoctor.outputDir}/html5") {
         into 'static/docs'
     }
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+
+    from file("build/asciidoc/html5/")
+    into file("src/main/resources/static/docs")
+}
+build {
+    dependsOn copyDocument
 }

--- a/Back/gradle/wrapper/gradle-wrapper.properties
+++ b/Back/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Back/src/docs/asciidoc/api.adoc
+++ b/Back/src/docs/asciidoc/api.adoc
@@ -83,5 +83,3 @@ operation::users/findByEmail[snippets='curl-request,http-request,http-response,r
 
 === User 삭제 [DELETE]
 operation::users/delete[snippets='curl-request,http-request,http-response,response-body,response-fields']
-=======
-operation::shops/find[snippets='curl-request,http-request,http-response,response-body,response-fields']

--- a/Back/src/docs/asciidoc/api.adoc
+++ b/Back/src/docs/asciidoc/api.adoc
@@ -56,30 +56,58 @@ URL은 `/api/`로 시작한다.
 The Shop provides the entry point into the service.
 
 === Shop 전체 조회 [GET]
-operation::shops/find[snippets='curl-request,http-request,http-response,response-body,response-fields']
+operation::shops/findAll[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-== User API
+== Sign Up API
 
 === User 회원가입 성공 [POST]
-operation::users/signup/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
+operation::signup/user/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
 === User 회원가입 실패 [POST]
-operation::users/signup/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
+operation::signup/user/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-=== User 로그인 성공 [POST]
-operation::users/login/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
+=== ADMIN 회원가입 성공 [POST]
+operation::signup/admin/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-=== User 로그인 실패 [POST]
-operation::users/login/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
+=== ADMIN 회원가입 실패 [POST]
+operation::signup/admin/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-=== User 전체 조회 [GET]
+=== CEO 회원가입 성공 [POST]
+operation::signup/ceo/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+=== CEO 회원가입 실패 [POST]
+operation::signup/ceo/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+== Login Api
+
+=== USER 로그인 성공 [POST]
+operation::login/user/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+=== USER 로그인 실패 [POST]
+operation::login/user/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+=== ADMIN 로그인 성공 [POST]
+operation::login/admin/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+=== ADMIN 로그인 실패 [POST]
+operation::login/admin/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+=== CEO 로그인 성공 [POST]
+operation::login/ceo/success[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+=== CEO 로그인 실패 [POST]
+operation::login/ceo/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
+== User Api
+
+=== USER 전체 조회 [GET]
 operation::users/findAll[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-=== User 조회_id [GET]
+=== USER 조회_id [GET]
 operation::users/findById[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-=== User 조회_email [GET]
+=== USER 조회_email [GET]
 operation::users/findByEmail[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
-=== User 삭제 [DELETE]
+=== USER 삭제 [DELETE]
 operation::users/delete[snippets='curl-request,http-request,http-response,response-body,response-fields']

--- a/Back/src/main/java/com/toogoodtogo/advice/ExceptionAdvice.java
+++ b/Back/src/main/java/com/toogoodtogo/advice/ExceptionAdvice.java
@@ -29,7 +29,7 @@ public class ExceptionAdvice {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected CommonResult defaultException(HttpServletRequest request, Exception e) {
-       // log.info(String.valueOf(e));
+        log.info(String.valueOf(e));
         return responseService.getFailResult
                 (Integer.parseInt(getMessage("unKnown.code")), getMessage("unKnown.msg"));
     }

--- a/Back/src/main/java/com/toogoodtogo/application/user/UserUseCase.java
+++ b/Back/src/main/java/com/toogoodtogo/application/user/UserUseCase.java
@@ -7,7 +7,7 @@ import com.toogoodtogo.web.users.UserResponseDto;
 import java.util.List;
 
 public interface UserUseCase {
-    Long save(UserRequestDto userDto);
+    //Long save(UserRequestDto userDto);
     UserResponseDto findById(Long id);
     UserResponseDto findByEmail(String email);
     List<UserResponseDto> findAllUser();

--- a/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
+++ b/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
@@ -44,7 +44,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                         // 권한 관리 대상 지정 옵션
                         // 메인 화면, 로그인 및 가입 접근은 누구나 가능
                         // 더 손봐야 함!!
-                .antMatchers("/api/signup", "/api/login", "/index").permitAll()
+                .antMatchers("/api/signup", "/api/login", "/").permitAll()
                 // 위에 "/", "" 추가시 에러뜸
 //                .antMatchers(HttpMethod.GET, "/oauth/kakao/**").permitAll()
 //                .antMatchers(HttpMethod.GET, "/exception/**").permitAll()

--- a/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
+++ b/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
@@ -51,7 +51,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 //                .anyRequest().hasRole("USER") // 그 외 나머지 요청은 인증된 회원만 가능
 //                .anyRequest().permitAll()
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
-                .antMatchers("/api/user/**").hasRole("USER")
+                .antMatchers("/api/user/**", "/api/users/**").hasRole("USER")
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(customAuthenticationEntryPoint)
@@ -63,8 +63,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity web) throws Exception {
-        // 관련 url 예외처리 손봐야 함!!
-        web.ignoring().antMatchers("/api.adoc");
+        web.ignoring().antMatchers("/docs/**");
         // static 경로
         web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }

--- a/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
+++ b/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
@@ -52,6 +52,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 //                .anyRequest().permitAll()
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
                 .antMatchers("/api/user/**", "/api/users/**").hasRole("USER")
+                .antMatchers("/api/common/**").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/api/ceo/**").hasRole("CEO")
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
+++ b/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
@@ -45,12 +45,13 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                         // 메인 화면, 로그인 및 가입 접근은 누구나 가능
                         // 더 손봐야 함!!
                 .antMatchers("/api/signup", "/api/login", "/index").permitAll()
+                // 위에 "/", "" 추가시 에러뜸
 //                .antMatchers(HttpMethod.GET, "/oauth/kakao/**").permitAll()
 //                .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
-                .anyRequest().hasRole("USER") // 그 외 나머지 요청은 인증된 회원만 가능
+//                .anyRequest().hasRole("USER") // 그 외 나머지 요청은 인증된 회원만 가능
 //                .anyRequest().permitAll()
-//                        .antMatchers("/admin/**").hasRole("ADMIN")
-//                        .antMatchers("/user/**").hasRole("USER")
+                .antMatchers("/api/admin/**").hasRole("ADMIN")
+                .antMatchers("/api/user/**").hasRole("USER")
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
+++ b/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
@@ -45,15 +45,16 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                         // 메인 화면, 로그인 및 가입 접근은 누구나 가능
                         // 더 손봐야 함!!
                 .antMatchers("/api/signup", "/api/login", "/").permitAll()
-                // 위에 "/", "" 추가시 에러뜸
 //                .antMatchers(HttpMethod.GET, "/oauth/kakao/**").permitAll()
 //                .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
 //                .anyRequest().hasRole("USER") // 그 외 나머지 요청은 인증된 회원만 가능
 //                .anyRequest().permitAll()
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
                 .antMatchers("/api/user/**", "/api/users/**").hasRole("USER")
-                .antMatchers("/api/common/**").hasAnyRole("USER", "ADMIN")
                 .antMatchers("/api/ceo/**").hasRole("CEO")
+                .antMatchers("/api/common/**").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/exception/**").permitAll()
+
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/Back/src/main/java/com/toogoodtogo/web/shops/ShopsController.java
+++ b/Back/src/main/java/com/toogoodtogo/web/shops/ShopsController.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/api/shops")
+@RequestMapping("/api/common/shops")
 @RequiredArgsConstructor
 public class ShopsController {
     private final ShopUseCase shopUseCase;

--- a/Back/src/main/java/com/toogoodtogo/web/users/UserResponseDto.java
+++ b/Back/src/main/java/com/toogoodtogo/web/users/UserResponseDto.java
@@ -3,6 +3,8 @@ package com.toogoodtogo.web.users;
 import com.toogoodtogo.domain.user.User;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class UserResponseDto {
     private final Long id;
@@ -10,6 +12,7 @@ public class UserResponseDto {
     private final String password;
     private final String name;
     private final String phoneNumber;
+    private final List<String> roles;
 
     public UserResponseDto(User user) {
         this.id = user.getId();
@@ -17,5 +20,6 @@ public class UserResponseDto {
         this.password = user.getPassword();
         this.name = user.getName();
         this.phoneNumber = user.getPhoneNumber();
+        this.roles = user.getRoles();
     }
 }

--- a/Back/src/main/java/com/toogoodtogo/web/users/UsersController.java
+++ b/Back/src/main/java/com/toogoodtogo/web/users/UsersController.java
@@ -17,17 +17,17 @@ public class UsersController {
     private final UserUseCase userUseCase;
     private final ResponseService responseService;
 
-    @GetMapping("/user/id/{userId}")
+    @GetMapping("/common/user/id/{userId}")
     public ApiResponse<UserResponseDto> findUserById (@PathVariable Long userId, @RequestParam String lang) {
         return responseService.getSingleResult(userUseCase.findById(userId));
     }
 
-    @GetMapping("/user/email/{email}")
+    @GetMapping("/common/user/email/{email}")
     public ApiResponse<UserResponseDto> findUserByEmail (@PathVariable String email, @RequestParam String lang) {
         return responseService.getSingleResult(userUseCase.findByEmail(email));
     }
 
-    @GetMapping("/users")
+    @GetMapping("/admin/users")
     public ApiResponseList<UserResponseDto> findAllUser() {
         return responseService.getListResult(userUseCase.findAllUser());
     }
@@ -38,7 +38,7 @@ public class UsersController {
 //        return responseService.getSingleResult(userService.update(userId, userRequestDto));
 //    }
 
-    @DeleteMapping("/user/{userId}")
+    @DeleteMapping("/admin/user/{userId}")
     public CommonResult delete(@PathVariable Long userId) {
         userUseCase.delete(userId);
         return responseService.getSuccessResult();

--- a/Back/src/main/java/com/toogoodtogo/web/users/sign/UserSignupRequestDto.java
+++ b/Back/src/main/java/com/toogoodtogo/web/users/sign/UserSignupRequestDto.java
@@ -18,6 +18,7 @@ public class UserSignupRequestDto {
     private String password;
     private String name;
     private String phoneNumber;
+    private String roles;
 
     public User toEntity(PasswordEncoder passwordEncoder) {
         return User.builder()
@@ -25,7 +26,7 @@ public class UserSignupRequestDto {
                 .password(passwordEncoder.encode(password))
                 .name(name)
                 .phoneNumber(phoneNumber)
-                .roles(Collections.singletonList("ROLE_USER"))
+                .roles(Collections.singletonList(roles))
                 .build();
     }
 
@@ -34,7 +35,7 @@ public class UserSignupRequestDto {
                 .email(email)
                 .name(name)
                 .phoneNumber(phoneNumber)
-                .roles(Collections.singletonList("ROLE_USER"))
+                .roles(Collections.singletonList(roles))
                 .build();
     }
 }

--- a/Back/src/test/java/com/toogoodtogo/web/shops/ShopsControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/shops/ShopsControllerTest.java
@@ -71,12 +71,12 @@ class ShopsControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"USER"})
-    void 가게목록조회() throws Exception {
+    @WithMockUser(roles = {"USER", "ADMIN"})
+    void findShops() throws Exception {
         //then
-        mvc.perform(get("/api/shops"))
+        mvc.perform(get("/api/common/shops"))
                 .andDo(print())
-                .andDo(document("shops/find",
+                .andDo(document("shops/findAll",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         responseFields(

--- a/Back/src/test/java/com/toogoodtogo/web/shops/ShopsControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/shops/ShopsControllerTest.java
@@ -77,6 +77,8 @@ class ShopsControllerTest {
         mvc.perform(get("/api/shops"))
                 .andDo(print())
                 .andDo(document("shops/find",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("success").description("shop data"),
                                 fieldWithPath("code").description("shop data"),

--- a/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
@@ -76,7 +76,7 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"USER"})
+    @WithMockUser(roles = {"USER"})
     public void 회원조회_userId() throws Exception {
         //given
         ResultActions actions = mockMvc.perform(
@@ -96,7 +96,8 @@ class UsersControllerTest {
                                 fieldWithPath("data.email").description("user email"),
                                 fieldWithPath("data.password").description("user password"),
                                 fieldWithPath("data.name").description("user name"),
-                                fieldWithPath("data.phoneNumber").description("user phoneNumber")
+                                fieldWithPath("data.phoneNumber").description("user phoneNumber"),
+                                fieldWithPath("data.roles").description("user roles")
                         )
                 ))
                 .andExpect(jsonPath("$.success").value(true))
@@ -107,7 +108,7 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"USER"})
+    @WithMockUser(roles = {"USER"})
     public void 회원조회_email() throws Exception {
         //given
         ResultActions actions = mockMvc.perform(
@@ -127,7 +128,8 @@ class UsersControllerTest {
                                 fieldWithPath("data.email").description("user email"),
                                 fieldWithPath("data.password").description("user password"),
                                 fieldWithPath("data.name").description("user name"),
-                                fieldWithPath("data.phoneNumber").description("user phoneNumber")
+                                fieldWithPath("data.phoneNumber").description("user phoneNumber"),
+                                fieldWithPath("data.roles").description("user roles")
                         )
                 ))
                 .andExpect(jsonPath("$.success").value(true))
@@ -138,7 +140,7 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"USER"})
+    @WithMockUser(roles = {"USER"})
     public void 전체회원조회() throws Exception {
         //then
         mockMvc.perform(get("/api/users"))
@@ -153,7 +155,8 @@ class UsersControllerTest {
                                 fieldWithPath("data.[].email").description("user email"),
                                 fieldWithPath("data.[].password").description("user password"),
                                 fieldWithPath("data.[].name").description("user name"),
-                                fieldWithPath("data.[].phoneNumber").description("user phoneNumber")
+                                fieldWithPath("data.[].phoneNumber").description("user phoneNumber"),
+                                fieldWithPath("data.[].roles").description("user roles")
                         )
                 ))
                 .andExpect(jsonPath("$.success").value(true))

--- a/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
@@ -172,7 +172,7 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"USER"})
+    @WithMockUser(roles = {"USER"})
     public void 회원삭제() throws Exception {
         //given
         //when

--- a/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -87,6 +88,8 @@ class UsersControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/findById",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("success").description("success"),
                                 fieldWithPath("code").description("code"),
@@ -119,6 +122,8 @@ class UsersControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/findByEmail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("success").description("success"),
                                 fieldWithPath("code").description("code"),
@@ -146,6 +151,8 @@ class UsersControllerTest {
         mockMvc.perform(get("/api/users"))
                 .andDo(print())
                 .andDo(document("users/findAll",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("success").description("success"),
                                 fieldWithPath("code").description("code"),
@@ -174,6 +181,8 @@ class UsersControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("success").description("success"),
                                 fieldWithPath("code").description("code"),

--- a/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
@@ -69,6 +69,20 @@ class UsersControllerTest {
                 .roles(Collections.singletonList("ROLE_USER"))
                 .build());
         id = Math.toIntExact(save.getId());
+        userRepository.save(User.builder()
+                .email("admin@email.com")
+                .password(passwordEncoder.encode("admin_pw"))
+                .name("adminA")
+                .phoneNumber("010-1111-1111")
+                .roles(Collections.singletonList("ROLE_ADMIN"))
+                .build());
+        userRepository.save(User.builder()
+                .email("ceo@email.com")
+                .password(passwordEncoder.encode("ceo_pw"))
+                .name("ceoA")
+                .phoneNumber("010-2222-2222")
+                .roles(Collections.singletonList("ROLE_CEO"))
+                .build());
     }
 
     @AfterEach
@@ -77,11 +91,11 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"USER"})
-    public void 회원조회_userId() throws Exception {
+    @WithMockUser(roles = {"USER", "ADMIN"})
+    public void findUser_userId() throws Exception {
         //given
         ResultActions actions = mockMvc.perform(
-                get("/api/user/id/{id}", id)
+                get("/api/common/user/id/{id}", id)
                 .param("lang", "ko"));
         //then
         //when
@@ -111,11 +125,11 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"USER"})
-    public void 회원조회_email() throws Exception {
+    @WithMockUser(roles = {"USER", "ADMIN"})
+    public void findUser_email() throws Exception {
         //given
         ResultActions actions = mockMvc.perform(
-                        get("/api/user/email/{email}", "email@email.com")
+                        get("/api/common/user/email/{email}", "email@email.com")
                         .param("lang", "ko"));
         //then
         //when
@@ -145,10 +159,10 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"USER"})
-    public void 전체회원조회() throws Exception {
+    @WithMockUser(roles = {"ADMIN"})
+    public void findUsers() throws Exception {
         //then
-        mockMvc.perform(get("/api/users"))
+        mockMvc.perform(get("/api/admin/users"))
                 .andDo(print())
                 .andDo(document("users/findAll",
                         preprocessRequest(prettyPrint()),
@@ -172,11 +186,11 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"USER"})
+    @WithMockUser(roles = {"ADMIN"})
     public void 회원삭제() throws Exception {
         //given
         //when
-        ResultActions actions = mockMvc.perform(delete("/api/user/{id}", id));
+        ResultActions actions = mockMvc.perform(delete("/api/admin/user/{id}", id));
         //then
         actions
                 .andDo(print())

--- a/Back/src/test/java/com/toogoodtogo/web/users/sign/SignControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/sign/SignControllerTest.java
@@ -102,7 +102,9 @@ class SignControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/login/success",
-                        preprocessRequest(prettyPrint()),
+                        preprocessRequest(
+//                                modifyUris().scheme("https").host("www.tgtg.com").removePort(),
+                                prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("login email"),

--- a/Back/src/test/java/com/toogoodtogo/web/users/sign/SignControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/sign/SignControllerTest.java
@@ -72,11 +72,25 @@ class SignControllerTest {
     @BeforeEach
     public void setUp() {
         userRepository.save(User.builder()
-                .email("email@email.com")
-                .password(passwordEncoder.encode("password"))
-                .name("name")
+                .email("user@email.com")
+                .password(passwordEncoder.encode("user_pw"))
+                .name("userA")
                 .phoneNumber("010-0000-0000")
                 .roles(Collections.singletonList("ROLE_USER"))
+                .build());
+        userRepository.save(User.builder()
+                .email("admin@email.com")
+                .password(passwordEncoder.encode("admin_pw"))
+                .name("adminA")
+                .phoneNumber("010-1111-1111")
+                .roles(Collections.singletonList("ROLE_ADMIN"))
+                .build());
+        userRepository.save(User.builder()
+                .email("ceo@email.com")
+                .password(passwordEncoder.encode("ceo_pw"))
+                .name("ceoA")
+                .phoneNumber("010-2222-2222")
+                .roles(Collections.singletonList("ROLE_CEO"))
                 .build());
     }
 
@@ -86,11 +100,11 @@ class SignControllerTest {
     }
 
     @Test
-    public void 로그인_성공() throws Exception {
+    public void user_login_success() throws Exception {
         //given
         String object = objectMapper.writeValueAsString(UserLoginRequestDto.builder()
-                .email("email@email.com")
-                .password("password")
+                .email("user@email.com")
+                .password("user_pw")
                 .build());
 
         //when
@@ -101,14 +115,14 @@ class SignControllerTest {
         //then
         actions
                 .andDo(print())
-                .andDo(document("users/login/success",
+                .andDo(document("login/user/success",
                         preprocessRequest(
 //                                modifyUris().scheme("https").host("www.tgtg.com").removePort(),
                                 prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("login email"),
-                                fieldWithPath("password").description("user password")
+                                fieldWithPath("password").description("login password")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("success"),
@@ -127,10 +141,10 @@ class SignControllerTest {
     }
 
     @Test
-    public void 로그인_실패() throws Exception {
+    public void user_login_fail() throws Exception {
         //given
         String object = objectMapper.writeValueAsString(UserLoginRequestDto.builder()
-                .email("email@email.com")
+                .email("user@email.com")
                 .password("wrongPassword")
                 .build());
         //when
@@ -141,12 +155,12 @@ class SignControllerTest {
         //then
         actions
                 .andDo(print())
-                .andDo(document("users/login/fail",
+                .andDo(document("login/user/fail",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("login email"),
-                                fieldWithPath("password").description("user password")
+                                fieldWithPath("password").description("login password")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("success"),
@@ -160,14 +174,163 @@ class SignControllerTest {
     }
 
     @Test
-    public void 회원가입_성공() throws Exception {
+    public void admin_login_success() throws Exception {
+        //given
+        String object = objectMapper.writeValueAsString(UserLoginRequestDto.builder()
+                .email("admin@email.com")
+                .password("admin_pw")
+                .build());
+
+        //when
+        ResultActions actions = mockMvc.perform(post("/api/login")
+                .content(object)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+        //then
+        actions
+                .andDo(print())
+                .andDo(document("login/admin/success",
+                        preprocessRequest(
+//                                modifyUris().scheme("https").host("www.tgtg.com").removePort(),
+                                prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("login email"),
+                                fieldWithPath("password").description("login password")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg"),
+                                fieldWithPath("data.grantType").description("grantType"),
+                                fieldWithPath("data.accessToken").description("accessToken"),
+                                fieldWithPath("data.refreshToken").description("refreshToken"),
+                                fieldWithPath("data.accessTokenExpireDate").description("accessTokenExpireDate")
+                        )
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.msg").exists());
+    }
+
+    @Test
+    public void admin_login_fail() throws Exception {
+        //given
+        String object = objectMapper.writeValueAsString(UserLoginRequestDto.builder()
+                .email("admin@email.com")
+                .password("wrongPassword")
+                .build());
+        //when
+        ResultActions actions = mockMvc.perform(post("/api/login")
+                .content(object)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+        //then
+        actions
+                .andDo(print())
+                .andDo(document("login/admin/fail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("login email"),
+                                fieldWithPath("password").description("login password")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg")
+                        )
+                ))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-1001));
+    }
+
+    @Test
+    public void ceo_login_success() throws Exception {
+        //given
+        String object = objectMapper.writeValueAsString(UserLoginRequestDto.builder()
+                .email("ceo@email.com")
+                .password("ceo_pw")
+                .build());
+
+        //when
+        ResultActions actions = mockMvc.perform(post("/api/login")
+                .content(object)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+        //then
+        actions
+                .andDo(print())
+                .andDo(document("login/ceo/success",
+                        preprocessRequest(
+//                                modifyUris().scheme("https").host("www.tgtg.com").removePort(),
+                                prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("login email"),
+                                fieldWithPath("password").description("login password")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg"),
+                                fieldWithPath("data.grantType").description("grantType"),
+                                fieldWithPath("data.accessToken").description("accessToken"),
+                                fieldWithPath("data.refreshToken").description("refreshToken"),
+                                fieldWithPath("data.accessTokenExpireDate").description("accessTokenExpireDate")
+                        )
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.msg").exists());
+    }
+
+    @Test
+    public void ceo_login_fail() throws Exception {
+        //given
+        String object = objectMapper.writeValueAsString(UserLoginRequestDto.builder()
+                .email("ceo@email.com")
+                .password("wrongPassword")
+                .build());
+        //when
+        ResultActions actions = mockMvc.perform(post("/api/login")
+                .content(object)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+        //then
+        actions
+                .andDo(print())
+                .andDo(document("login/ceo/fail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("login email"),
+                                fieldWithPath("password").description("login password")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg")
+                        )
+                ))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-1001));
+    }
+
+    @Test
+    public void user_signUp_success() throws Exception {
         //given
         long time = LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond();
         String object = objectMapper.writeValueAsString(UserSignupRequestDto.builder()
-                .email("email@email.com" + time)
-                .password("myPassword")
-                .name("myName")
-                .phoneNumber("010-0000-0000")
+                .email("userB@email.com" + time)
+                .password("userB_pw")
+                .name("userB")
+                .phoneNumber("010-4444-4444")
+                .roles("USER")
                 .build());
 
         //then
@@ -179,14 +342,15 @@ class SignControllerTest {
         //when
         actions
                 .andDo(print())
-                .andDo(document("users/signup/success",
+                .andDo(document("signup/user/success",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("user email"),
                                 fieldWithPath("password").description("user password"),
                                 fieldWithPath("name").description("user name"),
-                                fieldWithPath("phoneNumber").description("user phoneNumber")
+                                fieldWithPath("phoneNumber").description("user phoneNumber"),
+                                fieldWithPath("roles").description("user role")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("success"),
@@ -202,13 +366,14 @@ class SignControllerTest {
     }
 
     @Test
-    public void 회원가입_실패() throws Exception {
+    public void user_signUp_fail() throws Exception {
         //given
         String object = objectMapper.writeValueAsString(UserSignupRequestDto.builder()
-                .email("email@email.com")
-                .password("password")
-                .name("myName")
-                .phoneNumber("010-0000-0000")
+                .email("user@email.com")
+                .password("userB_pw")
+                .name("userB")
+                .phoneNumber("010-4444-4444")
+                .roles("USER")
                 .build());
 
         //when
@@ -220,14 +385,15 @@ class SignControllerTest {
         //then
         actions
                 .andDo(print())
-                .andDo(document("users/signup/fail",
+                .andDo(document("signup/user/fail",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("user email"),
                                 fieldWithPath("password").description("user password"),
                                 fieldWithPath("name").description("user name"),
-                                fieldWithPath("phoneNumber").description("user phoneNumber")
+                                fieldWithPath("phoneNumber").description("user phoneNumber"),
+                                fieldWithPath("roles").description("user role")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("success"),
@@ -241,22 +407,192 @@ class SignControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"GUEST"})
-    public void 접근실패() throws Exception {
+    public void admin_signUp_success() throws Exception {
+        //given
+        long time = LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond();
+        String object = objectMapper.writeValueAsString(UserSignupRequestDto.builder()
+                .email("adminB@email.com" + time)
+                .password("adminB_pw")
+                .name("adminB")
+                .phoneNumber("010-5555-5555")
+                .roles("ADMIN")
+                .build());
+
         //then
-        mockMvc.perform(get("/api/users"))
+        ResultActions actions = mockMvc.perform(post("/api/signup")
+                .content(object)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //when
+        actions
+                .andDo(print())
+                .andDo(document("signup/admin/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("admin email"),
+                                fieldWithPath("password").description("admin password"),
+                                fieldWithPath("name").description("admin name"),
+                                fieldWithPath("phoneNumber").description("admin phoneNumber"),
+                                fieldWithPath("roles").description("admin role")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg"),
+                                fieldWithPath("data").description("data")
+                        )
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.msg").exists());
+    }
+
+    @Test
+    public void admin_signUp_fail() throws Exception {
+        //given
+        String object = objectMapper.writeValueAsString(UserSignupRequestDto.builder()
+                .email("admin@email.com")
+                .password("adminB_pw")
+                .name("adminB")
+                .phoneNumber("010-5555-5555")
+                .roles("ADMIN")
+                .build());
+
+        //when
+        ResultActions actions = mockMvc.perform(post("/api/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(object));
+
+        //then
+        actions
+                .andDo(print())
+                .andDo(document("signup/admin/fail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("admin email"),
+                                fieldWithPath("password").description("admin password"),
+                                fieldWithPath("name").description("admin name"),
+                                fieldWithPath("phoneNumber").description("admin phoneNumber"),
+                                fieldWithPath("roles").description("admin role")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg")
+                        )
+                ))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-1002));
+    }
+
+    @Test
+    public void ceo_signUp_success() throws Exception {
+        //given
+        long time = LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond();
+        String object = objectMapper.writeValueAsString(UserSignupRequestDto.builder()
+                .email("ceoB@email.com" + time)
+                .password("ceoB_pw")
+                .name("ceoB")
+                .phoneNumber("010-6666-6666")
+                .roles("CEO")
+                .build());
+
+        //then
+        ResultActions actions = mockMvc.perform(post("/api/signup")
+                .content(object)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //when
+        actions
+                .andDo(print())
+                .andDo(document("signup/ceo/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("ceo email"),
+                                fieldWithPath("password").description("ceo password"),
+                                fieldWithPath("name").description("ceo name"),
+                                fieldWithPath("phoneNumber").description("ceo phoneNumber"),
+                                fieldWithPath("roles").description("ceo role")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg"),
+                                fieldWithPath("data").description("data")
+                        )
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.msg").exists());
+    }
+
+    @Test
+    public void ceo_signUp_fail() throws Exception {
+        //given
+        String object = objectMapper.writeValueAsString(UserSignupRequestDto.builder()
+                .email("ceo@email.com")
+                .password("ceoB_pw")
+                .name("ceoB")
+                .phoneNumber("010-6666-6666")
+                .roles("CEO")
+                .build());
+
+        //when
+        ResultActions actions = mockMvc.perform(post("/api/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(object));
+
+        //then
+        actions
+                .andDo(print())
+                .andDo(document("signup/ceo/fail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("ceo email"),
+                                fieldWithPath("password").description("ceo password"),
+                                fieldWithPath("name").description("ceo name"),
+                                fieldWithPath("phoneNumber").description("ceo phoneNumber"),
+                                fieldWithPath("roles").description("ceo role")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("success"),
+                                fieldWithPath("code").description("code"),
+                                fieldWithPath("msg").description("msg")
+                        )
+                ))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-1002));
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void access_success() throws Exception {
+        //then
+        mockMvc.perform(get("/api/admin/users"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = {"USER"})
+    public void access_denied() throws Exception {
+        //then
+        mockMvc.perform(get("/api/admin/users"))
                 .andDo(print())
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/exception/accessDenied"));
         ;
-    }
-
-    @Test
-    @WithMockUser(roles = {"GUEST", "USER"})
-    public void 접근성공() throws Exception {
-        //then
-        mockMvc.perform(get("/api/users"))
-                .andDo(print())
-                .andExpect(status().isOk());
     }
 }

--- a/Back/src/test/java/com/toogoodtogo/web/users/sign/SignControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/sign/SignControllerTest.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -100,6 +102,8 @@ class SignControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/login/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("login email"),
                                 fieldWithPath("password").description("user password")
@@ -136,6 +140,8 @@ class SignControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/login/fail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("login email"),
                                 fieldWithPath("password").description("user password")
@@ -172,6 +178,8 @@ class SignControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/signup/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("user email"),
                                 fieldWithPath("password").description("user password"),
@@ -211,6 +219,8 @@ class SignControllerTest {
         actions
                 .andDo(print())
                 .andDo(document("users/signup/fail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("user email"),
                                 fieldWithPath("password").description("user password"),
@@ -229,7 +239,7 @@ class SignControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"GUEST"})
+    @WithMockUser(roles = {"GUEST"})
     public void 접근실패() throws Exception {
         //then
         mockMvc.perform(get("/api/users"))
@@ -240,7 +250,7 @@ class SignControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "mockUser", roles = {"GUEST", "USER"})
+    @WithMockUser(roles = {"GUEST", "USER"})
     public void 접근성공() throws Exception {
         //then
         mockMvc.perform(get("/api/users"))


### PR DESCRIPTION
1. test 코드에 prettyPrint 추가로 직관적인 확인 가능
2. 유저 조회 시 roles도 조회 가능
3. SecurityConfiguration에 REST Docs html 접근 설정 추가
4. ADMIN, CEO, USER로 권한 생성 및 SecurityConfiguration에서 권한마다 접근 허용 설정
5. ADMIN, CEO, USER마다 controller 권한 설정과 그에 따른 Mapping 수정 및 테스트 생성
6. snippet 폴더 구조 변경

앞으로 필요한 것
1. 로그아웃 구현
2. Refresh 토큰을 DB가 아닌 Redis을 이용해서 구현 및 이에 맞는 로그아웃 구현
3. 지금 구현한 것은 회원가입 할 때 roles을 같이 넣어준 방식인데 실질적으로 어떻게 구현될 건지 구상 후 리팩토링