### PR TITLE
reissue 로직 수정, 로그인 패스워드 오류 로직 추가

### DIFF
--- a/Back/.gitignore
+++ b/Back/.gitignore
@@ -25,7 +25,6 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-application-jwt.yml
 
 ### NetBeans ###
 /nbproject/private/
@@ -36,3 +35,4 @@ application-jwt.yml
 
 ### VS Code ###
 .vscode/
+/src/main/resources/application-local.yml

--- a/Back/src/main/docs/asciidoc/api.adoc
+++ b/Back/src/main/docs/asciidoc/api.adoc
@@ -80,6 +80,11 @@ operation::login/manager/success[snippets='curl-request,http-request,http-respon
 === MANAGER 로그인 실패 [POST]
 operation::login/manager/fail[snippets='curl-request,http-request,http-response,response-body,response-fields']
 
+== 토큰 Api
+
+=== 토큰 재발급 [POST]
+operation::reissue[snippets='curl-request,http-request,http-response,response-body,response-fields']
+
 == User Api
 
 === USER 조회 [GET]

--- a/Back/src/main/java/com/toogoodtogo/advice/ExceptionAdvice.java
+++ b/Back/src/main/java/com/toogoodtogo/advice/ExceptionAdvice.java
@@ -44,12 +44,22 @@ public class ExceptionAdvice {
 
     /***
      * -1001
-     * 유저 이메일 로그인 실패 시 발생시키는 예외
+     * 유저 이메일 로그인 시 이메일이 틀렸을때 발생시키는 예외
      */
     @ExceptionHandler(CEmailLoginFailedException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     protected ErrorResponse emailLoginFailedException(HttpServletRequest request, CEmailLoginFailedException e) {
-        return new ErrorResponse("Email Login Failed", getMessage("emailLoginFailed.msg"));
+        return new ErrorResponse("Login Email Wrong", getMessage("emailLoginFailed.msg"));
+    }
+
+    /***
+     * -1001
+     * 유저 이메일 로그인 시 비밀번호가 틀렸을때 발생시키는 예외
+     */
+    @ExceptionHandler(CPasswordLoginFailedException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    protected ErrorResponse passwordLoginFailedException(HttpServletRequest request, CPasswordLoginFailedException e) {
+        return new ErrorResponse("Login Password Wrong", getMessage("passwordLoginFailed.msg"));
     }
 
     /***

--- a/Back/src/main/java/com/toogoodtogo/advice/exception/CPasswordLoginFailedException.java
+++ b/Back/src/main/java/com/toogoodtogo/advice/exception/CPasswordLoginFailedException.java
@@ -1,0 +1,13 @@
+package com.toogoodtogo.advice.exception;
+
+public class CPasswordLoginFailedException  extends RuntimeException {
+    public CPasswordLoginFailedException() { super(); }
+
+    public CPasswordLoginFailedException(String message) {
+        super(message);
+    }
+
+    public CPasswordLoginFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Back/src/main/java/com/toogoodtogo/application/security/SignService.java
+++ b/Back/src/main/java/com/toogoodtogo/application/security/SignService.java
@@ -31,7 +31,7 @@ public class SignService {
                 .orElseThrow(CEmailLoginFailedException::new);
         // 회원 패스워드 일치 여부 확인
         if (!passwordEncoder.matches(userLoginRequest.getPassword(), user.getPassword()))
-            throw new CEmailLoginFailedException();
+            throw new CPasswordLoginFailedException();
         // AccessToken, RefreshToken 발급
         TokenDto tokenDto = jwtTokenProvider.createTokenDto(user.getId(), user.getRole());
         // RefreshToken 저장

--- a/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
+++ b/Back/src/main/java/com/toogoodtogo/configuration/security/SecurityConfiguration.java
@@ -58,7 +58,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 //                .anyRequest().permitAll()
                 .antMatchers("/api/user/**", "/api/users/**", "/api/shops/**").hasRole("USER")
                 .antMatchers("/api/manager/**").hasRole("MANAGER")
-                .antMatchers("/api/me").hasAnyRole("USER", "MANAGER")
+                .antMatchers("/api/me", "/api/reissue").hasAnyRole("USER", "MANAGER")
                 .antMatchers("/h2-console/**").permitAll()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .anyRequest().denyAll()

--- a/Back/src/main/java/com/toogoodtogo/domain/security/RefreshToken.java
+++ b/Back/src/main/java/com/toogoodtogo/domain/security/RefreshToken.java
@@ -20,7 +20,7 @@ public class RefreshToken extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Long tokenKey;
+    private Long userId;
 
     @Column(nullable = false)
     private String token;
@@ -31,8 +31,8 @@ public class RefreshToken extends BaseTimeEntity {
     }
 
     @Builder
-    public RefreshToken(Long tokenKey, String token) {
-        this.tokenKey = tokenKey;
+    public RefreshToken(Long userId, String token) {
+        this.userId = userId;
         this.token = token;
     }
 }

--- a/Back/src/main/java/com/toogoodtogo/domain/security/RefreshTokenRepository.java
+++ b/Back/src/main/java/com/toogoodtogo/domain/security/RefreshTokenRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByTokenKey(Long key);
+    Optional<RefreshToken> findByUserId(Long userId);
 }

--- a/Back/src/main/java/com/toogoodtogo/web/users/UsersController.java
+++ b/Back/src/main/java/com/toogoodtogo/web/users/UsersController.java
@@ -8,9 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -23,7 +20,7 @@ public class UsersController {
         return new ApiResponse(userUseCase.findUser(user.getId()));
     }
 
-    @PatchMapping("/user")
+    @PatchMapping("/me")
     public ApiResponse<UserDetailResponse> updateUser (@CurrentUser User user, @RequestBody UserUpdateRequest userUpdateRequest) {
         return new ApiResponse(userUseCase.update(user.getId(), userUpdateRequest));
     }

--- a/Back/src/main/resources/i18n/exception_en.yml
+++ b/Back/src/main/resources/i18n/exception_en.yml
@@ -7,7 +7,10 @@ userNotFound:
   msg: "This member not exist"
 emailLoginFailed:
   code: "-1001"
-  msg: "It's an ID you didn't sign up for, or it's an incorrect password."
+  msg: "It's an ID you didn't sign up for."
+passwordLoginFailed:
+  code: "-1001"
+  msg: "It's an incorrect password."
 emailSignupFailed:
   code: "-1002"
   msg: "This email is already subscribed."

--- a/Back/src/main/resources/i18n/exception_ko.yml
+++ b/Back/src/main/resources/i18n/exception_ko.yml
@@ -7,7 +7,10 @@ userNotFound:
   msg: "존재하지 않는 회원입니다."
 emailLoginFailed:
   code: "-1001"
-  msg: "가입하지 않은 아이디이거나, 잘못된 비밀번호입니다."
+  msg: "가입하지 않은 아이디입니다."
+passwordLoginFailed:
+  code: "-1001"
+  msg: "잘못된 비밀번호입니다."
 emailSignupFailed:
   code: "-1002"
   msg: "이미 가입된 이메일입니다."

--- a/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
+++ b/Back/src/test/java/com/toogoodtogo/web/users/UsersControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -112,7 +111,6 @@ class UsersControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = "USER")
     public void updateUser() throws Exception {
         //given
         String object = objectMapper.writeValueAsString(UserUpdateRequest.builder()
@@ -121,7 +119,7 @@ class UsersControllerTest {
                 .build());
 
         //when
-        ResultActions actions = mockMvc.perform(patch("/api/user")
+        ResultActions actions = mockMvc.perform(patch("/api/me")
                 .content(object)
                 .header("Authorization", token.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
유저 업데이트 url /api/user에서 /api/me로 수정
.gitignore에 local.yml 추가
refreshToken 필드 이름 수정
/reissue 접근 권한 설정
reissue 에러 이슈 해결 (user 못찾아왔음)
api.adoc reissue 업데이트

패스워드 오류 로직 추가